### PR TITLE
Added link to Material Icons in woff format for IE11

### DIFF
--- a/src/assets/scss/components/_layertree.scss
+++ b/src/assets/scss/components/_layertree.scss
@@ -58,6 +58,8 @@
       @include row(table);
       & .mat-grid-list {
         & md-grid-tile {
+          overflow: visible;
+          height: 49px;
           & md-icon {
             font-size: 1em;
             line-height: 2em;

--- a/src/assets/scss/lib/material-icons/_material-icons.scss
+++ b/src/assets/scss/lib/material-icons/_material-icons.scss
@@ -2,7 +2,10 @@
   font-family: 'Material Icons';
   font-style: normal;
   font-weight: 400;
-  src: local('Material Icons'), local('MaterialIcons-Regular'), url(https://fonts.gstatic.com/s/materialicons/v19/2fcrYFNaTjcS6g4U3t-Y5ZjZjT5FdEJ140U2DJYC3mY.woff2) format('woff2');
+  src: local('Material Icons'), 
+    local('MaterialIcons-Regular'), 
+    url(https://fonts.gstatic.com/s/materialicons/v19/2fcrYFNaTjcS6g4U3t-Y5ZjZjT5FdEJ140U2DJYC3mY.woff2) format('woff2'),
+    url(https://fonts.gstatic.com/s/materialicons/v28/2fcrYFNaTjcS6g4U3t-Y5ewrjPiaoEww8AihgqWRJAo.woff) format('woff');
 }
 
 .material-icons {
@@ -17,5 +20,7 @@
   white-space: nowrap;
   word-wrap: normal;
   direction: ltr;
+  font-feature-settings: 'liga';
+  -webkit-font-feature-settings: 'liga';
   -webkit-font-smoothing: antialiased;
 }


### PR DESCRIPTION
Material icons were failing to render in IE11 as the only font link was in woff2 format. This merge adds in a link to the woff format of the material icons as well as some updated css for IE:
```
 font-feature-settings: 'liga';
 -webkit-font-feature-settings: 'liga';
````
as per material design icon guide at https://google.github.io/material-design-icons/

Also updated _layertree.scss as IE11 was rendering collapse / hide button above div.

Before:
![image](https://user-images.githubusercontent.com/1078015/29301692-61a47698-81c1-11e7-8d82-cbbb0cc56612.png)


After:
![image](https://user-images.githubusercontent.com/1078015/29301693-658ca8ca-81c1-11e7-943a-f9d66fe7b575.png)

Tested on IE 11.0.9600.18762