### PR TITLE
defaultDataProjection changed to dataProjection (since 5.0.0)

### DIFF
--- a/projects/mangol/src/lib/modules/featureinfo/featureinfo.service.ts
+++ b/projects/mangol/src/lib/modules/featureinfo/featureinfo.service.ts
@@ -80,7 +80,7 @@ export class FeatureinfoService {
           const format =
             dataProjection !== featureProjection
               ? new GeoJSON({
-                  defaultDataProjection: dataProjection,
+                  dataProjection: dataProjection,
                   featureProjection: featureProjection
                 })
               : this.geojsonFormat;

--- a/src/app/pages/demo-featureinfo/demo-featureinfo.component.ts
+++ b/src/app/pages/demo-featureinfo/demo-featureinfo.component.ts
@@ -100,7 +100,7 @@ export class DemoFeatureinfoComponent implements OnInit, OnDestroy {
                 url:
                   'http://openlayers.org/en/latest/examples/data/geojson/countries.geojson',
                 format: new GeoJSON({
-                  defaultDataProjection: 'EPSG:4326',
+                  dataProjection: 'EPSG:4326',
                   featureProjection: 'EPSG:900913'
                 })
               })


### PR DESCRIPTION
Hi there, 
I recently made an effort to provide basic typings for OL5 
(https://github.com/OSHistory/generate_ol_types). 

Using the resulting types (released under:
https://github.com/OSHistory/generate_ol_types/releases/tag/v1.0.0-alpha.1) 
I managed to build your fine application/library. However I found 
some deprecated references to dataProjection (this branch). 

For around 3 other issues i created a seperate branch called 
`typeCompatible`, which are due to missing Event-Types etc.
